### PR TITLE
Fix temporary convenience typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Now, you can enjoy videos from the Apple video source.
 
 By selecting the Apple Server as the video source and enabling the reverse proxy option, you will use the built-in reverse proxy to fetch videos from Apple indirectly.
 
-This is juet for temporary convenience, it is not recommended to use the built-in reverse proxy for an extended period as it is only a temporary solution.
+This is just for temporary convenience, it is not recommended to use the built-in reverse proxy for an extended period as it is only a temporary solution.
 
 I cannot guarantee the long-term availability of this built-in reverse proxy.
 

--- a/src/instructions.html
+++ b/src/instructions.html
@@ -52,7 +52,7 @@
     <h2>Use built-in reverse proxy as video source</h2>
     <p>By selecting the Apple Server as the video source and enabling the reverse proxy option, you will use the
       built-in reverse proxy to fetch videos from Apple indirectly.</p>
-    <p>This is juet for temporary convenience, it is not recommended to use the built-in reverse proxy for an extended
+    <p>This is just for temporary convenience, it is not recommended to use the built-in reverse proxy for an extended
       period as it is only a temporary solution.</p>
     <p>I cannot guarantee the long-term availability of this built-in reverse proxy.</p>
 


### PR DESCRIPTION
## Summary
- correct spelling of "just" in README
- apply same fix in instructions

## Testing
- `grep -n juet -R README.md src/instructions.html`