### PR TITLE
Add trimTitle tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "macos-screen-saver-as-chrome-new-tab",
+  "version": "1.0.0",
+  "description": "Testing for trimTitle",
+  "type": "commonjs",
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "jest": "^29.6.2"
+  }
+}

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -52,7 +52,9 @@ const defaultQuotes = [
 ];
 
 // 初始化
-document.addEventListener("DOMContentLoaded", initSettings);
+if (typeof document !== "undefined") {
+  document.addEventListener("DOMContentLoaded", initSettings);
+}
 
 // 主程序
 async function initSettings() {
@@ -1059,4 +1061,9 @@ function setupFullScreenListener(videoElement, audioElement) {
   document.addEventListener("mozfullscreenchange", onFullScreenChange);
   document.addEventListener("webkitfullscreenchange", onFullScreenChange);
   document.addEventListener("MSFullscreenChange", onFullScreenChange);
+}
+
+// Export for testing
+if (typeof module !== "undefined" && module.exports) {
+  module.exports.trimTitle = trimTitle;
 }

--- a/tests/trimTitle.test.js
+++ b/tests/trimTitle.test.js
@@ -1,0 +1,13 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { trimTitle } = require('../src/js/popup');
+
+test('trims ASCII strings longer than limit with ellipsis', () => {
+  const result = trimTitle('abcdefghijklmnopqrstuvwxyz', 10);
+  assert.strictEqual(result, 'abcdefghij...');
+});
+
+test('multibyte characters count as length 2 and are trimmed correctly', () => {
+  const result = trimTitle('你好你好你好', 5);
+  assert.strictEqual(result, '你好...');
+});


### PR DESCRIPTION
## Summary
- add npm package manifest with Jest dev dependency
- guard DOM access in `popup.js` and export `trimTitle`
- test `trimTitle` behavior for ASCII and multibyte text

## Testing
- `node --test tests/trimTitle.test.js`
- `npm test --silent`